### PR TITLE
Fixes tooltip showing when no ndpe have been launched

### DIFF
--- a/components/GameWorld.js
+++ b/components/GameWorld.js
@@ -212,7 +212,7 @@ export default function GameWorld() {
                 setTooltip("Ev")
             } else {
                 const ndpeIndex = ndpeLaunchGroupsRef.current?.indexOf(target)
-                if (ndpeIndex !== -1) {
+                if (ndpeLaunchGroupsRef.current && ndpeIndex !== -1) {
                     setTooltip(`ndpeImpulse,${ndpeIndex}`)
                 }
             }


### PR DESCRIPTION
Fixes undefined tooltip bug:

<img width="690" alt="image" src="https://user-images.githubusercontent.com/570771/189417421-654c2983-7371-4d9c-954a-834ee43a25f2.png">
